### PR TITLE
Switches Prelude to Universum and Refactors String to Text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
-.PHONY: run ghcid
+.PHONY: run build ghcid
 
 run:
 	@stack install
 
+build:
+	@stack build
+
+clean:
+	@stack clean
+	@rm -r .stack-work
+
+ghci:
+	@stack ghci --ghci-options=-fobject-code
+
 ghcid:
-	@ghcid -c "stack ghci --ghci-options=-fno-code"
+	@ghcid -c "stack ghci --ghci-options=-fobject-code"

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
+.PHONY: run ghcid
+
 run:
 	@stack install
+
+ghcid:
+	@ghcid -c "stack ghci --ghci-options=-fno-code"

--- a/nbx.cabal
+++ b/nbx.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: e7bb6d209699ad5dc3754798b6d520698132df6fadb8036d3b54a22d456d0ec0
+-- hash: 2a17428df5d4149311b39b1846e9b14c27946ddacda241b26ad3f82c8dcf384f
 
 name:           nbx
 version:        0.1.0.0
@@ -38,7 +38,7 @@ executable nbx
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude OverloadedStrings
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Werror -Wincomplete-record-updates -Wincomplete-uni-patterns -Wtabs -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       ansi-terminal
     , async

--- a/nbx.cabal
+++ b/nbx.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 87ba2857750c44cd9aeeb66ee3853604d9150d01c674313900667b6094c1788a
+-- hash: e7bb6d209699ad5dc3754798b6d520698132df6fadb8036d3b54a22d456d0ec0
 
 name:           nbx
 version:        0.1.0.0
@@ -37,6 +37,7 @@ executable nbx
       Paths_nbx
   hs-source-dirs:
       src
+  default-extensions: NoImplicitPrelude OverloadedStrings
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       ansi-terminal
@@ -49,4 +50,5 @@ executable nbx
     , time
     , turtle
     , typed-process
+    , universum
   default-language: Haskell2010

--- a/nbx.cabal
+++ b/nbx.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 2a17428df5d4149311b39b1846e9b14c27946ddacda241b26ad3f82c8dcf384f
+-- hash: a0bd9a4220512c4601cbc6940a278fc801a971d9fbafdaa2683ebc5439534964
 
 name:           nbx
 version:        0.1.0.0
@@ -27,14 +27,6 @@ source-repository head
 
 executable nbx
   main-is: Main.hs
-  other-modules:
-      Command
-      Print
-      Shell
-      Shell.Concurrency
-      Shell.Internal
-      Shell.Types
-      Paths_nbx
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude OverloadedStrings
@@ -51,4 +43,12 @@ executable nbx
     , turtle
     , typed-process
     , universum
+  other-modules:
+      Command
+      Print
+      Shell
+      Shell.Concurrency
+      Shell.Internal
+      Shell.Types
+      Paths_nbx
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,13 @@ dependencies:
 - typed-process
 - universum
 
+ghc-options:
+  - -Wall
+  - -Werror
+  - -Wincomplete-record-updates
+  - -Wincomplete-uni-patterns
+  - -Wtabs
+
 # library:
 #   source-dirs: src
 

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,10 @@ extra-source-files:
 # common to point users to the README.md file.
 description:         Please see the README on Github at <https://github.com/loganmac/nbx#readme>
 
+default-extensions:
+- NoImplicitPrelude
+- OverloadedStrings
+
 dependencies:
 - ansi-terminal
 - async
@@ -30,6 +34,7 @@ dependencies:
 - time
 - turtle
 - typed-process
+- universum
 
 # library:
 #   source-dirs: src

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-| Commands recognized by the CLI, and how to parse them
 -}
 module Command where
 
+import           Universum
 import           Data.Text (Text)
 import           Turtle    (Parser, options, subcommand, (<|>))
 

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -3,7 +3,6 @@
 module Command where
 
 import           Universum
-import           Data.Text (Text)
 import           Turtle    (Parser, options, subcommand, (<|>))
 
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import           Universum
 import           Command (Command (..), parse)
 import qualified Print
 import           Shell   (Shell)
@@ -14,9 +15,9 @@ main = do
 
   -- TODO: turn this into verbose mode
   -- let header x = do
-  --       putStrLn ""
-  --       putStrLn x
-  --       putStrLn ""
+  --       putTextLn ""
+  --       putTextLn x
+  --       putTextLn ""
   -- shell <- Shell.new verboseDriver
 
   cmd   <- parse                        -- parse the command from the CLI
@@ -29,13 +30,13 @@ main = do
 execute :: Shell -> Print.Header -> Command -> IO ()
 execute shell header cmd =
   case cmd of
-    Main    -> putStrLn "For help, run 'nbx -h'."
-    Init    -> putStrLn "INIT!"
+    Main    -> putTextLn "For help, run 'nbx -h'."
+    Init    -> putTextLn "INIT!"
     Push    -> pushCmd  shell header
-    Status  -> putStrLn "STATUS!"
-    Setup   -> putStrLn "SETUP!"
-    Implode -> putStrLn "IMPLODE!"
-    Version -> putStrLn "NBX version 0.0.1"
+    Status  -> putTextLn "STATUS!"
+    Setup   -> putTextLn "SETUP!"
+    Implode -> putTextLn "IMPLODE!"
+    Version -> putTextLn "NBX version 0.0.1"
 
 -- | run the push command
 -- > nbx push
@@ -58,6 +59,7 @@ pushCmd shell header = do
 -- SHELL DISPLAY DRIVER
 
 -- | a display driver that pretty-prints output from processes with a spinner
+displayDriver :: Shell.Driver
 displayDriver = Shell.Driver
   { Shell.formatOut     = Print.formatOut
   , Shell.formatErr     = Print.formatErr
@@ -74,14 +76,15 @@ displayDriver = Shell.Driver
 windowsDisplayDriver = displayDriver {Shell.spinner = Print.spinner Print.windowsSpinner}
 
 -- | a display driver that just logs everything out
+verboseDriver :: Shell.Driver
 verboseDriver = Shell.Driver
-  { Shell.formatOut     = id
-  , Shell.formatErr     = id
-  , Shell.formatSuccess = id
-  , Shell.formatFailure = id
+  { Shell.formatOut     = identity
+  , Shell.formatErr     = identity
+  , Shell.formatSuccess = identity
+  , Shell.formatFailure = identity
   , Shell.toSpinner     = pure ()
-  , Shell.handleOutput  = putStrLn
-  , Shell.handleSuccess = \str           -> pure ()
-  , Shell.handleFailure = \task fail buf -> pure ()
-  , Shell.spinner       = \pos prompt    -> pure ()
+  , Shell.handleOutput  = putTextLn
+  , Shell.handleSuccess = \_str             -> pure ()
+  , Shell.handleFailure = \_task _fail _buf -> pure ()
+  , Shell.spinner       = \_pos _prompt     -> pure ()
   }

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -73,6 +73,7 @@ displayDriver = Shell.Driver
   }
 
 -- | a windows display driver
+windowsDisplayDriver :: Shell.Driver
 windowsDisplayDriver = displayDriver {Shell.spinner = Print.spinner Print.windowsSpinner}
 
 -- | a display driver that just logs everything out

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -2,8 +2,8 @@
 -}
 module Print where
 
-import           Universum
 import           Prelude             ((!!))
+import           Universum
 
 import qualified System.Console.ANSI as Term
 import qualified Text.Regex          as Regex
@@ -59,7 +59,7 @@ spinner (SpinnerTheme theme) pos prompt = do
   putText taskIndent
   putTextLn $
     style Bold . color Yellow $
-      (toText [theme !! mod pos (length theme)]) <>
+      toText [theme !! mod pos (length theme)] <>
         " " <> (style Underline . color Yellow $ prompt)
   putTextLn ""
 
@@ -102,7 +102,7 @@ output :: Text -> IO ()
 output str = do
   Term.cursorUpLine 1
   Term.clearLine
-  putTextLn (taskOutputIndent <> str)
+  putTextLn $ taskOutputIndent <> str
   toSpinner
 
 -- | Prints the success message
@@ -115,10 +115,11 @@ failure task failure buffer = do
   printResult failure
   putTextLn ""
   putTextLn $ headerIndent <>
-    (style Bold . style Reverse . color Red $ "Error executing task '" <> task <> "':")
+    ( style Bold . style Reverse . color Red
+    $ "Error executing task '" <> task <> "':" )
   putTextLn ""
 
-  forM_ (reverse buffer) (\x -> putTextLn $ taskIndent <> x)
+  forM_ (reverse buffer) $ \x -> putTextLn $ taskIndent <> x
   putTextLn ""
 
 -- | clears the spinner then prints the string in its place

--- a/src/Print.hs
+++ b/src/Print.hs
@@ -36,7 +36,7 @@ type Header = Text -> IO ()
 header :: Text -> IO ()
 header s = do
   putTextLn ""
-  putTextLn $ headerIndent <> (style Bold . color Cyan $ (s <> " :"))
+  putTextLn $ headerIndent <> (style Bold . fgColor Cyan $ (s <> " :"))
   putTextLn ""
 
 --------------------------------------------------------------------------------
@@ -58,9 +58,9 @@ spinner (SpinnerTheme theme) pos prompt = do
   Term.clearLine
   putText taskIndent
   putTextLn $
-    style Bold . color Yellow $
+    style Bold . fgColor Yellow $
       (toText [theme !! mod pos (length theme)]) <>
-        " " <> (style Underline . color Yellow $ prompt)
+        " " <> (style Underline . fgColor Yellow $ prompt)
   putTextLn ""
 
 -- | Move to the spinner
@@ -78,15 +78,15 @@ formatOut = style Faint . strip
 
 -- | formats an error
 formatErr :: Text -> Text
-formatErr = style Normal . color Red . strip
+formatErr = style Normal . fgColor Red . strip
 
 -- | formats a success string
 formatSuccess :: Text -> Text
-formatSuccess str = style Bold . color Green $ "✓ " <> str
+formatSuccess str = style Bold . fgColor Green $ "✓ " <> str
 
 -- | formats a failure string
 formatFailure :: Text -> Text
-formatFailure str = style Bold . color Red $ "✖ " <> str
+formatFailure str = style Bold . fgColor Red $ "✖ " <> str
 
 -- | removes terminal control sequences from the string
 strip :: Text -> Text
@@ -111,11 +111,11 @@ success = printResult
 
 -- | Prints the message as a failure (red with an x)
 failure :: Text -> Text -> [Text] -> IO ()
-failure task failure buffer = do
-  printResult failure
+failure task msg buffer = do
+  printResult msg
   putTextLn ""
   putTextLn $ headerIndent <>
-    (style Bold . style Reverse . color Red $ "Error executing task '" <> task <> "':")
+    (style Bold . style Reverse . fgColor Red $ "Error executing task '" <> task <> "':")
   putTextLn ""
 
   forM_ (reverse buffer) (\x -> putTextLn $ taskIndent <> x)
@@ -145,8 +145,8 @@ data Style
   deriving (Enum)
 
 -- | Helper to set foreground color
-color :: Color -> Text -> Text
-color = colorize Foreground
+fgColor :: Color -> Text -> Text
+fgColor = colorize Foreground
 
 -- | Helper to set background color
 bgColor :: Color -> Text -> Text
@@ -166,9 +166,9 @@ colorize section color str =
 
 -- | Wrap the text in the escape codes to format according to the color and style
 style :: Style -> Text -> Text
-style style str =
-    "\x1b[" <>            -- escape code
-    show (fromEnum style) -- style
-    <> "m" <>             -- delim
-    str <>                -- string
-    "\x1b[0m"             -- reset
+style style' str =
+    "\x1b[" <>             -- escape code
+    show (fromEnum style') -- style
+    <> "m" <>              -- delim
+    str <>                 -- string
+    "\x1b[0m"              -- reset

--- a/src/Shell.hs
+++ b/src/Shell.hs
@@ -5,6 +5,7 @@ module Shell
 (new, Shell, Driver(..))
 where
 
+import           Universum
 import           Shell.Internal (mkProcessor, processor, run)
 import           Shell.Types    (Cmd, Driver (..), Output (..), Processor (..),
                                  Shell, Task)

--- a/src/Shell.hs
+++ b/src/Shell.hs
@@ -2,13 +2,12 @@
 based on the response.
 -}
 module Shell
-(new, Shell, Driver(..))
+(Driver(..), Shell, new)
 where
 
 import           Universum
-import           Shell.Internal (mkProcessor, processor, run)
-import           Shell.Types    (Cmd, Driver (..), Output (..), Processor (..),
-                                 Shell, Task)
+import           Shell.Internal (mkProcessor, run)
+import           Shell.Types (Driver(..), Shell)
 
 -- | creates a new processor to run external processes in,
 -- then partially applies it and the display driver

--- a/src/Shell/Concurrency.hs
+++ b/src/Shell/Concurrency.hs
@@ -10,7 +10,7 @@ module Shell.Concurrency
 import           Universum                hiding (second)
 
 import           Control.Concurrent       (threadDelay)
-import           Control.Concurrent.Async (Async, async, cancel, link)
+import           Control.Concurrent.Async (Async, async, link)
 import           Control.Concurrent.STM   (TQueue, newTQueue,
                                            readTQueue, tryReadTQueue,
                                            writeTQueue)

--- a/src/Shell/Concurrency.hs
+++ b/src/Shell/Concurrency.hs
@@ -7,10 +7,11 @@ module Shell.Concurrency
   , newLock, wait, done
   ) where
 
-import           Control.Concurrent       (MVar, newEmptyMVar, putMVar,
-                                           takeMVar, threadDelay)
+import           Universum                hiding (second)
+
+import           Control.Concurrent       (threadDelay)
 import           Control.Concurrent.Async (Async, async, cancel, link)
-import           Control.Concurrent.STM   (TQueue, atomically, newTQueue,
+import           Control.Concurrent.STM   (TQueue, newTQueue,
                                            readTQueue, tryReadTQueue,
                                            writeTQueue)
 

--- a/src/Shell/Internal.hs
+++ b/src/Shell/Internal.hs
@@ -8,6 +8,7 @@ module Shell.Internal where
 import           Universum
 
 import           Control.Monad         (unless)
+import           Data.Text.IO          (hGetLine)
 import           Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
 import           GHC.IO.Handle         (Handle)
 import           Shell.Concurrency     (Chan, Lock, done, maybeReceive,
@@ -17,7 +18,7 @@ import           Shell.Types           (Cmd, Driver (..), Output (..),
                                         Processor (..), Task)
 import qualified Shell.Types           as Driver
 import           System.Exit           (ExitCode (..))
-import           System.IO             (hGetLine, hIsEOF)
+import           System.IO             (hIsEOF)
 import           System.Process.Typed  (Process, closed, createPipe, getStderr,
                                         getStdout, setStderr, setStdin,
                                         setStdout, shell, waitExitCode,
@@ -140,7 +141,7 @@ handleOut chan wrap h lock = do
         done <- hIsEOF h
         unless done $ do
           out <- hGetLine h
-          send chan $ wrap (toText out)
+          send chan $ wrap out
           loop
   loop
   done lock

--- a/src/Shell/Internal.hs
+++ b/src/Shell/Internal.hs
@@ -13,12 +13,12 @@ import           GHC.IO.Handle         (Handle)
 import           Shell.Concurrency     (Chan, Lock, done, maybeReceive,
                                         millisecond, newChan, newLock, receive,
                                         send, sleep, spawn, wait)
-import           Shell.Types           (Cmd, Driver (..), Output (..),
-                                        Processor (..), Task)
+import           Shell.Types           (Cmd, Driver, Output (..),
+                                        Processor (Processor), Task)
 import qualified Shell.Types           as Driver
 import           System.Exit           (ExitCode (..))
 import           System.IO             (hGetLine, hIsEOF)
-import           System.Process.Typed  (Process, closed, createPipe, getStderr,
+import           System.Process.Typed  (closed, createPipe, getStderr,
                                         getStdout, setStderr, setStdin,
                                         setStdout, shell, waitExitCode,
                                         withProcess)
@@ -87,7 +87,7 @@ run (Processor input output) driver task cmd = do
         handleAndLoop :: Int-> POSIXTime -> Text -> IO ()
         handleAndLoop spinPos spinTime str = do
           handleOutput str
-          loop spinPos spinTime ([str] <> buffer)
+          loop spinPos spinTime (str : buffer)
 
         handleMsg :: Int -> POSIXTime -> Output -> IO ()
         handleMsg spinPos spinTime msg = case msg of
@@ -137,8 +137,8 @@ runCmd output cmd = do
 handleOut :: Chan Output -> (Text -> Output) -> Handle -> Lock -> IO ()
 handleOut chan wrap h lock = do
   let loop = do
-        done <- hIsEOF h
-        unless done $ do
+        isDone <- hIsEOF h
+        unless isDone $ do
           out <- hGetLine h
           send chan $ wrap (toText out)
           loop

--- a/src/Shell/Types.hs
+++ b/src/Shell/Types.hs
@@ -1,33 +1,34 @@
 module Shell.Types where
 
+import           Universum
 import           Shell.Concurrency (Chan)
 
 -- | Driver is a collection of functions that
 -- describe what to do on process output
 data Driver = Driver
-  { formatOut     :: String -> String
-  , formatErr     :: String -> String
-  , formatSuccess :: String -> String
-  , formatFailure :: String -> String
-  , spinner       :: Int -> String -> IO ()
-  , handleOutput  :: String -> IO ()
-  , handleSuccess :: String -> IO ()
-  , handleFailure :: String -> String -> [String] -> IO ()
+  { formatOut     :: Text -> Text
+  , formatErr     :: Text -> Text
+  , formatSuccess :: Text -> Text
+  , formatFailure :: Text -> Text
+  , spinner       :: Int -> Text -> IO ()
+  , handleOutput  :: Text -> IO ()
+  , handleSuccess :: Text -> IO ()
+  , handleFailure :: Text -> Text -> [Text] -> IO ()
   , toSpinner     :: IO ()
   }
 
 -- | The output of running an external process
-data Output = Msg String | Err String | Success | Failure Int
+data Output = Msg Text | Err Text | Success | Failure Int
 
 -- | Processor has an input channel (for sending commands)
 -- and an output channel (for reading the output)
-data Processor = Processor (Chan String) (Chan Output)
+data Processor = Processor (Chan Text) (Chan Output)
 
 -- | The type for a partially applied `Processor.run`
 type Shell = (Task -> Cmd -> IO ())
 
 -- | Task is the description of an external process
-type Task = String
+type Task = Text
 
 -- | Cmd is the external command like `cat foo` to run
-type Cmd = String
+type Cmd = Text


### PR DESCRIPTION
Pretty much what it says on the tin. We discussed this in Slack, but a small summary of the changes include:

- Pervasively switched `String` types to `Text`
- Switched the standard Prelude out to Serokell's Universum prelude
- Moved `OverloadedStrings` and `NoImplicitPrelude` to `default-extensions` because they're just plain useful to have turned on
- Added some useful GHC options (namely `-Wall` and `-Werror`, as well as stuff concerning record updates and pattern matching not covered by `-Wall`)